### PR TITLE
fix: also include generated } tokens when fixing closing token positions

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -376,7 +376,7 @@
     Rewriter.prototype.fixOutdentLocationData = function() {
       return this.scanTokens(function(token, i, tokens) {
         var prevLocationData;
-        if (!(token[0] === 'OUTDENT' || (token.generated && token[0] === 'CALL_END'))) {
+        if (!(token[0] === 'OUTDENT' || (token.generated && token[0] === 'CALL_END') || (token.generated && token[0] === '}'))) {
           return 1;
         }
         prevLocationData = tokens[i - 1][2];

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -375,7 +375,8 @@ class exports.Rewriter
   fixOutdentLocationData: ->
     @scanTokens (token, i, tokens) ->
       return 1 unless token[0] is 'OUTDENT' or
-        (token.generated and token[0] is 'CALL_END')
+        (token.generated and token[0] is 'CALL_END') or
+        (token.generated and token[0] is '}')
       prevLocationData = tokens[i - 1][2]
       token[2] =
         first_line:   prevLocationData.last_line

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -515,6 +515,27 @@ test "Verify OUTDENT and CALL_END tokens are located at the end of the previous 
     eq token[0], 'CALL_END'
     assertAtCloseCurly(token)
 
+test "Verify generated } tokens are located at the end of the previous token", ->
+  source = '''
+    a(b, ->
+      c: () ->
+        if d
+          e
+    )
+  '''
+  tokens = CoffeeScript.tokens source
+  [..., identifier, outdent1, outdent2, closeCurly, outdent3, callEnd,
+    terminator] = tokens
+  eq identifier[0], 'IDENTIFIER'
+  assertAtIdentifier = (token) ->
+    eq token[2].first_line, identifier[2].last_line
+    eq token[2].first_column, identifier[2].last_column
+    eq token[2].last_line, identifier[2].last_line
+    eq token[2].last_column, identifier[2].last_column
+
+  for token in [outdent1, outdent2, closeCurly, outdent3]
+    assertAtIdentifier(token)
+
 test "Verify real CALL_END tokens have the right position", ->
   source = '''
     a()


### PR DESCRIPTION
Closes https://github.com/decaffeinate/decaffeinate/issues/458
Closes https://github.com/decaffeinate/decaffeinate/issues/461
Closes https://github.com/decaffeinate/decaffeinate/issues/504

Just like OUTDENT and CALL_END tokens, close-curly-brace tokens can be generated
without having a real location, and if that position overlaps with a later
token, it can cause the AST to have bad location data. Just like the other two
token types, we now give `}` tokens the position of the previous real token,
which makes all AST nodes have reasonable locations.