### PR TITLE
fix: correct import case to lowercase.

### DIFF
--- a/lib/coffee-script/nodes.d.ts
+++ b/lib/coffee-script/nodes.d.ts
@@ -1,4 +1,4 @@
-import Scope from './Scope';
+import Scope from './scope';
 import { Token } from './lexer';
 
 export type LocationData = {


### PR DESCRIPTION
Annoyingly, this works fine in case-insensitive-but-case-preserving file systems (like HFS+ on macOS), but fails on case-sensitive file systems (like presumably ext3 on Linux as run by TravisCI).