### PR TITLE
fix: place ending heregex tokens one index earlier

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -365,11 +365,11 @@
             double: true
           }, this.formatHeregex);
           if (flags) {
-            this.token(',', ',', index, 0);
-            this.token('STRING', '"' + flags + '"', index, flags.length);
+            this.token(',', ',', index - 1, 0);
+            this.token('STRING', '"' + flags + '"', index - 1, flags.length);
           }
-          this.token(')', ')', end, 0);
-          this.token('REGEX_END', ')', end, 0);
+          this.token(')', ')', end - 1, 0);
+          this.token('REGEX_END', ')', end - 1, 0);
       }
       return end;
     };

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -294,10 +294,10 @@ exports.Lexer = class Lexer
         @token 'CALL_START', '(', 0, 0
         @mergeInterpolationTokens tokens, {delimiter: '"', double: yes}, @formatHeregex
         if flags
-          @token ',', ',', index, 0
-          @token 'STRING', '"' + flags + '"', index, flags.length
-        @token ')', ')', end, 0
-        @token 'REGEX_END', ')', end, 0
+          @token ',', ',', index - 1, 0
+          @token 'STRING', '"' + flags + '"', index - 1, flags.length
+        @token ')', ')', end - 1, 0
+        @token 'REGEX_END', ')', end - 1, 0
 
     end
 

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -585,6 +585,29 @@ test "Verify indented heredocs have the right position", ->
   eq stringToken[2].last_line, 3
   eq stringToken[2].last_column, 4
 
+test "Verify heregexes with interpolations have the right ending position", ->
+  source = '''
+    [a ///#{b}///g]
+  '''
+  [..., stringEnd, comma, flagsString, regexCallEnd, regexEnd, fnCallEnd,
+    arrayEnd, terminator] = CoffeeScript.tokens source
+
+  eq comma[0], ','
+  eq arrayEnd[0], ']'
+
+  assertColumn = (token, column) ->
+    eq token[2].first_line, 0
+    eq token[2].first_column, column
+    eq token[2].last_line, 0
+    eq token[2].last_column, column
+
+  arrayEndColumn = arrayEnd[2].first_column
+  for token in [comma, flagsString]
+    assertColumn token, arrayEndColumn - 2
+  for token in [regexCallEnd, regexEnd, fnCallEnd]
+    assertColumn token, arrayEndColumn - 1
+  assertColumn arrayEnd, arrayEndColumn
+
 test "Verify all tokens get a location", ->
   doesNotThrow ->
     tokens = CoffeeScript.tokens testScript


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/710

The lexer generates fake tokens for interpolated heregexes, and the ending
tokens were being placed where the start (inclusive) and end (inclusive) index
were one past the end of the heregex. This meant that in a case like
`[a ///#{b}///]`, the end tokens of the heregex and also the implicit function
call end were all being placed at the `]`, so the AST location data would say
that the function call ends at the end of the `]`. This caused decaffeinate to
insert the close-paren after the `]`, which is wrong.

To fix, I can just subtract 1 from the position of those ending heregex tokens
so that their end lines up with the end of the heregex itself. This is similar
to previous fixes that changed `OUTDENT` and `CALL_END` tokens so that the end
of the token lines up with the end of the AST node.