### PR TITLE
fix: mark `Op#second` as optional

### DIFF
--- a/lib/coffee-script/nodes.d.ts
+++ b/lib/coffee-script/nodes.d.ts
@@ -550,7 +550,7 @@ export class While extends Base {
 export class Op extends Base {
   operator: string;
   first: Base;
-  second: Base;
+  second?: Base;
   flip: boolean;
 
   constructor(op: string, first: Base, second: Base, flip: boolean);


### PR DESCRIPTION
`Op` represents both binary and unary operations, and in the unary case the second operand is not present.