### PR TITLE
fix: properly update location data when setting a call to use `new`

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -896,6 +896,22 @@
 
     Call.prototype.children = ['variable', 'args'];
 
+    Call.prototype.updateLocationDataIfMissing = function(locationData) {
+      var base, ref3;
+      if (this.locationData && this.needsUpdatedStartLocation) {
+        this.locationData.first_line = locationData.first_line;
+        this.locationData.first_column = locationData.first_column;
+        base = ((ref3 = this.variable) != null ? ref3.base : void 0) || this.variable;
+        if (base.needsUpdatedStartLocation) {
+          this.variable.locationData.first_line = locationData.first_line;
+          this.variable.locationData.first_column = locationData.first_column;
+          base.updateLocationDataIfMissing(locationData);
+        }
+        delete this.needsUpdatedStartLocation;
+      }
+      return Call.__super__.updateLocationDataIfMissing.apply(this, arguments);
+    };
+
     Call.prototype.newInstance = function() {
       var base, ref3;
       base = ((ref3 = this.variable) != null ? ref3.base : void 0) || this.variable;
@@ -904,6 +920,7 @@
       } else {
         this.isNew = true;
       }
+      this.needsUpdatedStartLocation = true;
       return this;
     };
 


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/809

In a case like `new A().b(c)`, the jison structure ends up being different from
the resulting AST. To the jison parser, this is the `new` unary operator applied
to the expression `A().b(c)`. When the unary operator is applied, the
`Call.prototype.newInstance` function traverses into the leftmost function call
and sets the `isNew` flag to true, and the `Op` constructor returns the `Call`
node so that the call is used in place of the unary operator. However, the code
wasn't updating the node location data, so this commit fixes that.

It's sort of hard to get the location data in `newInstance`, so we set a flag on
every affected node in `newInstance` and override `updateLocationDataIfMissing`
(which is called with the location data after the fact) so that it updates just
the starting position.