### PR TITLE
fix: improve token positions in two CSX cases

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -752,7 +752,7 @@
           return 0;
         }
         [input, id, colon] = match;
-        origin = this.token('CSX_TAG', id, 1, id.length);
+        origin = this.token('CSX_TAG', id, 0, id.length + 1);
         this.token('CALL_START', '(');
         this.token('[', '[');
         this.ends.push({
@@ -1067,7 +1067,7 @@
         if (!braceInterpolator) {
           // We are not using `{` and `}`, so wrap the interpolated tokens instead.
           open = this.makeToken('(', '(', offsetInChunk, 0);
-          close = this.makeToken(')', ')', offsetInChunk + index, 0);
+          close = this.makeToken(')', ')', offsetInChunk + index - 1, 0);
           nested = [open, ...nested, close];
         }
         // Push a fake `'TOKENS'` token, which will get turned into real tokens later.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -571,7 +571,7 @@ exports.Lexer = class Lexer
         prev[0] not in COMPARABLE_LEFT_SIDE
       )
       [input, id, colon] = match
-      origin = @token 'CSX_TAG', id, 1, id.length
+      origin = @token 'CSX_TAG', id, 0, id.length + 1
       @token 'CALL_START', '('
       @token '[', '['
       @ends.push tag: '/>', origin: origin, name: id
@@ -798,7 +798,7 @@ exports.Lexer = class Lexer
       unless braceInterpolator
         # We are not using `{` and `}`, so wrap the interpolated tokens instead.
         open = @makeToken '(', '(', offsetInChunk, 0
-        close = @makeToken ')', ')', offsetInChunk + index, 0
+        close = @makeToken ')', ')', offsetInChunk + index - 1, 0
         nested = [open, nested..., close]
 
       # Push a fake `'TOKENS'` token, which will get turned into real tokens later.

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1506,9 +1506,9 @@ test "CSX error: non-matching tag names", ->
     <div><span></div></span>
   ''',
   '''
-    [stdin]:1:7: error: expected corresponding CSX closing tag for span
+    [stdin]:1:6: error: expected corresponding CSX closing tag for span
     <div><span></div></span>
-          ^^^^
+         ^^^^^
   '''
 
 test "CSX error: bare expressions not allowed", ->


### PR DESCRIPTION
* The start of an artificial CSX call was the start of the tag name instead of
  the start of the `<`, so the range of the decaffeinate node was wrong.
* The artificial `)` after a nested CSX tag was placed so that the end of the
  `)` is one after the end of the `>`. This made nested CSX tags one character
  too long, which broke some interpolation code in decaffeinate-parser.

This is sort of a quick fix and I'll use tests in decaffeinate-parser to verify
correctness. The first change also makes one of the CS error messages worse.
There may be a more robust fix to these issues, but this seems to work for now.